### PR TITLE
timer & score system changes

### DIFF
--- a/src/Timer.js
+++ b/src/Timer.js
@@ -1,0 +1,41 @@
+export class Timer {
+  constructor(gameStates, setGameState, saveScore) {
+    this.time = 60 * 5;
+    this.timerID = null;
+    this.gameStates = gameStates;
+    this.setGameState = setGameState;
+    this.saveScore = saveScore;
+  }
+
+  run = () => {
+    this.timerID = setInterval(() => {
+      this.time--;
+      if (this.time <= 0) {
+        this.saveScore();
+        this.setGameState(this.gameStates.DEAD, "TIME'S UP");
+        clearInterval(this.timerID);
+      }
+    }, 1000);
+  };
+
+  pause = () => {
+    clearInterval(this.timerID);
+  };
+
+  show = (s) => {
+    s.textSize(24);
+    s.fill(255);
+    s.text(`time left: ${this.secondsToMinutes()}`, s.width - 150, 50);
+  };
+
+  secondsToMinutes = () => {
+    const minutes = Math.floor(this.time / 60);
+    const seconds = this.formatSeconds(this.time - minutes * 60);
+    return `${minutes}:${seconds}`;
+  };
+
+  formatSeconds = (seconds) => {
+    const s = seconds.toString();
+    return s.length == 2 ? s : `0${s}`;
+  };
+}

--- a/src/app.js
+++ b/src/app.js
@@ -362,8 +362,13 @@ const game = (s) => {
               })
             );
             gun.deleteBullet(bulletIdx);
-            enemyManager.hitEnemy(s, enemyIdx, bullet.damage, bullet);
-            player.updateScore(enemy.pointValue);
+            enemyManager.hitEnemy(
+              s,
+              enemyIdx,
+              bullet.damage,
+              bullet,
+              player.updateScore
+            );
           }
         });
 

--- a/src/app.js
+++ b/src/app.js
@@ -380,6 +380,7 @@ const game = (s) => {
         if (isEnemyColidingPlayer) {
           if (!player.shield.isActive) {
             player.hit(enemy, gameState, setGameState, gameStates, s.saveScore);
+            player.applyPenalty(enemy.pointValue);
           } else player.takeShieldDamage(1);
           enemyManager.hitEnemy(s, enemyIdx, Infinity);
         }

--- a/src/character/Player.js
+++ b/src/character/Player.js
@@ -171,7 +171,7 @@ export class Player {
   };
 
   updateScore = (points) => {
-    this.multiplier += 0.125;
+    this.multiplier += points * 0.05;
     this.score += Math.floor(points * this.multiplier);
   };
 

--- a/src/character/Player.js
+++ b/src/character/Player.js
@@ -83,7 +83,7 @@ export class Player {
   hit = (enemy, gameState, setGameState, gameStates, saveScore) => {
     this.health -= enemy.pointValue * 2;
     if (this.health <= 0 && gameState !== gameStates.DEAD) {
-      setGameState(gameStates.DEAD);
+      setGameState(gameStates.DEAD, "YOU ARE DEAD");
       saveScore();
       this.p5.random(this.deathSounds).play();
     } else {

--- a/src/character/Server.js
+++ b/src/character/Server.js
@@ -1,6 +1,6 @@
 export class Server {
   constructor() {
-    this.maxToxicity = 1_000;
+    this.maxToxicity = 100;
     this.toxicity = 0;
   }
 

--- a/src/character/Server.js
+++ b/src/character/Server.js
@@ -37,8 +37,8 @@ export class Server {
     this.toxicity += damage;
 
     if (this.toxicity >= this.maxToxicity && gameState !== gameStates.DEAD) {
-      setGameState(gameStates.DEAD);
       saveScore();
+      setGameState(gameStates.DEAD, "GAME OVER");
     }
   };
 }

--- a/src/enemy/EnemyManager.js
+++ b/src/enemy/EnemyManager.js
@@ -21,7 +21,7 @@ export class EnemyManager {
     this.enemies.forEach((enemy) => enemy.show(s));
   };
 
-  hitEnemy = (s, index, damage, bullet, updatePlayerScore) => {
+  hitEnemy = (s, index, damage, bullet, updatePlayerScore = () => {}) => {
     const enemy = this.enemies[index];
     if (enemy) {
       enemy.hit(damage);

--- a/src/enemy/EnemyManager.js
+++ b/src/enemy/EnemyManager.js
@@ -21,12 +21,13 @@ export class EnemyManager {
     this.enemies.forEach((enemy) => enemy.show(s));
   };
 
-  hitEnemy = (s, index, damage, bullet) => {
+  hitEnemy = (s, index, damage, bullet, updatePlayerScore) => {
     const enemy = this.enemies[index];
     if (enemy) {
       enemy.hit(damage);
 
       if (enemy.health <= 0) {
+        updatePlayerScore(enemy.pointValue);
         if (enemy.type === "BOSS") {
           this.isBossRound = false;
           this.powerupManager.dispatchPowerup(enemy.x, enemy.y);


### PR DESCRIPTION
- game now runs against a 5 minute (for now) timer
- "death" scene now has three states:
  - "YOU ARE DEAD" - when you take too much damage 
  - "GAME OVER" - when the server takes too much damage
  - "TIME'S UP" - when the timer runs out 
- reworked score/multiplier system 
  - multiplier/score are only updated when enemies are killed, not just hit
    - fixes an exploit where you intentionally don't get damage buffs and end up w/ higher score
  - multiplier is now based on point value of enemy
  - when you take direct/unshielded damage, your multiplier is reset and you take a point penalty equal to the enemy's point value   
- dramatically reduced server health `1000 --> 100`
